### PR TITLE
Make `mluau` more rust -> rust ffi friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ anyhow = ["dep:anyhow", "error-send"]
 userdata-wrappers = ["parking_lot/send_guard"]
 dynamic-userdata = ["luau"]
 error-value = []
+unsafe-ffi = []
 
 # deprecated features
 serialize = ["serde"]


### PR DESCRIPTION
Under the feature flag "unsafe-ffi":

Adds `unsafe fn Lua::push_to_stack` which allows you to push an arbitrary LuaValue (or anything that implements `IntoLua`) directly onto the Luau stack. 

This is useful for returning values from a cdylib opening function that need to be returned on the stack for ffi purposes.

Hides a debug assertion that kept getting triggered in `src/util/userdata.rs` that was complaining about the mlua internal metatable going missing. This is probably responsible for the fact that all errors retrieved in the dylib get glitched out to runtime error: userdata<0x...> instead of actually being readable. I need help debugging that issue :/.

