### PR TITLE
Improve speed of IntoLua impls for many common byteish types

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -565,6 +565,13 @@ impl IntoLua for Cow<'_, str> {
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.as_bytes())?))
     }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        // use str's implementation of push_into_specified_stack so we don't accidentally 
+        // hit fallback into_lua case where it converts into { number } instead of string
+        (&*self).push_into_specified_stack(lua, state)
+    }
 }
 
 impl IntoLua for Box<str> {
@@ -596,6 +603,13 @@ impl IntoLua for CString {
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.as_bytes())?))
     }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        // converting to BString prevents &[u8] from silently putting a { number } onto stack
+        // instead of a string in the fallback case of unlikely memory error/huge string
+        push_bytes_into_stack(BString::from(self.into_bytes()), lua, state)
+    }
 }
 
 impl FromLua for CString {
@@ -626,6 +640,13 @@ impl IntoLua for &CStr {
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.to_bytes())?))
     }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        // converting to BString prevents &[u8] from silently putting a { number } onto stack
+        // instead of a string in the fallback case of unlikely memory error/huge string
+        push_bytes_into_stack(BStr::new(self.to_bytes()), lua, state)
+    }
 }
 
 impl IntoLua for Cow<'_, CStr> {
@@ -633,12 +654,22 @@ impl IntoLua for Cow<'_, CStr> {
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.to_bytes())?))
     }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        push_bytes_into_stack(BStr::new(self.to_bytes()), lua, state)
+    }
 }
 
 impl IntoLua for BString {
     #[inline]
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self)?))
+    }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        push_bytes_into_stack(self, lua, state)
     }
 }
 
@@ -687,6 +718,11 @@ impl IntoLua for &BStr {
     #[inline]
     fn into_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self)?))
+    }
+
+    #[inline]
+    unsafe fn push_into_specified_stack(self, lua: &RawLua, state: *mut ffi::lua_State) -> Result<()> {
+        push_bytes_into_stack(self, lua, state)
     }
 }
 


### PR DESCRIPTION
Adds push_into_specified_stack and specifically uses push_bytes_into_stack since all the affected ones are basically wrappers around bytes. Avoids an easy pitfall around accidentally defaulting to &[u8] IntoLua implementation that would inadvertently create an array of numbers instead of a string